### PR TITLE
v1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "meteor-sync-eventemitter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meteor-sync-eventemitter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Allows syncing event emitter events over multiple meteor servers.",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
* 🐛 TypeError: Class constructor SyncedStream cannot be invoked without 'new' (#1)