### PR TITLE
FIX - Skip 'remove' because it removes Collection in DB faster than observeChanges handles the new insert

### DIFF
--- a/src/syncEventEmitter.js
+++ b/src/syncEventEmitter.js
@@ -50,7 +50,6 @@ export default function syncEventEmitter(syncer, emitFn = 'emit') {
           if (this.syncedIds.indexOf(id) > -1) {
             // delete if event is from current instance
             this.syncedIds = this.syncedIds.filter(item => item !== id);
-            syncer.remove(id);
             return;
           }
 


### PR DESCRIPTION
When running 'meteor-sync-eventemitter' in combination with Meteor.Streamer on Meteor Galaxy Hosting (https://galaxy.meteor.com/) in combination with our Mongo 4.2 DB running on Mongo Atlas Cloud we noticed that the 'onInsert' callback was not executing. 

It seems that the 'remove' done by the instance triggering the 'emit' is removing the entry faster than other instances are picking up the observe on the change. By deleting the remove action in the code we made it work again as expected. We now rely on the index cleaning up messages after 60 seconds.

What are your thoughts on this @maxnowack?